### PR TITLE
Update alpine and added bash install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine3.14
+FROM python:alpine3.21
 
 COPY assets/ /opt/resource/
 
@@ -10,7 +10,10 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 # Rationale: https://github.com/hadolint/hadolint/wiki/DL3013
 RUN apk update && \
     apk upgrade && \
-    apk add --no-cache curl skopeo
+    apk add --no-cache \
+         bash~=5.2 \
+         curl \
+         skopeo
 
 # Install Python dependency
 RUN pip install --no-cache-dir requests==2.31.0


### PR DESCRIPTION
**What's Included**

This PR updates the Trivy resource image to include Bash, allowing the `trivy-image-scan` task to use bash. 

**Why This Is Needed**

The `trivy-image-scan` task uses bash-only syntax (arrays, `[[ ]]`, etc.) This update ensures the task runs reliably and adheres to internal shell scripting guidelines.

**Testing**

- Built image locally.
- Ran docker run and confirmed bash is installed + executable.